### PR TITLE
Change security group rule

### DIFF
--- a/kubecluster.yaml
+++ b/kubecluster.yaml
@@ -152,16 +152,16 @@ resources:
     properties:
       rules:
         - protocol: tcp # api-server
-          port_range_min: 443
-          port_range_max: 443
+          port_range_min: 6443
+          port_range_max: 6443
 
   secgroup_node:
     type: OS::Neutron::SecurityGroup
     properties:
       rules:
-        - protocol: icmp
         - protocol: tcp
-        - protocol: udp
+          port_range_min: 30000
+          port_range_max: 32767
 
   ######################################################################
   #


### PR DESCRIPTION
kube-api use 6443 for secure port.
NodePort use 30000-32767.

I checked other LISTEN ports.
- master
  22: ssh
  4194,10250,10255: kubelet
  10251: kube-schedular
  10252: kube-controller-manager
  8080,6443: kube-api
- worker (allow all ports currently)
  22: ssh
  4194,10250,10255: kubelet

Node can access all port of other node in same cluster.
I think it is enough to allow only secure port and nodePort to outside.

@zreigz  What do you think?
