### PR TITLE
unnecessary containerized flag is removed from master

### DIFF
--- a/fragments/master.sh
+++ b/fragments/master.sh
@@ -201,7 +201,6 @@ start_k8s(){
         -d \
         gcr.io/google_containers/hyperkube-${ARCH}:v${K8S_VERSION} \
         /hyperkube kubelet \
-            --containerized \
             --hostname-override=${MASTER_IP} \
             --address="0.0.0.0" \
             --api-servers=http://localhost:8080 \


### PR DESCRIPTION
Either containerized or shared volumes should be used. 
