### PR TITLE
[WIP] scaleup scaledown

### DIFF
--- a/kube-update.sh
+++ b/kube-update.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")
+
+source "$KUBE_ROOT/openrc-default.sh"
+
+echo ${KUBE_ROOT}
+
+source "${KUBE_ROOT}/util.sh"
+
+echo "... calling kube-up" >&2
+update-heat-script
+
+
+exit 0

--- a/kubecluster.yaml
+++ b/kubecluster.yaml
@@ -292,6 +292,26 @@ resources:
 
   ######################################################################
   #
+  # 
+
+  vm_scaleup:
+    type: OS::Heat::ScalingPolicy
+    properties:
+      adjustment_type: change_in_capacity
+      auto_scaling_group_id: {get_resource: kube_minions}
+      cooldown: 60
+      scaling_adjustment: 1
+
+  vm_scaledown:
+    type: OS::Heat::ScalingPolicy
+    properties:
+      adjustment_type: change_in_capacity
+      auto_scaling_group_id: {get_resource: kube_minions}
+      cooldown: 60
+      scaling_adjustment: -1
+
+  ######################################################################
+  #
   # kubernetes minions. This is an autoscaling group that will initially
   # create <number_of_minions> minions, and will scale up to
   # <max_number_of_minions> based on CPU utilization.
@@ -344,3 +364,25 @@ outputs:
     value: {get_attr: [kube_minions, outputs_list, kube_minion_external_ip]}
     description: >
       Here is the list of the "public" addresses of all Kubernetes worker nodes.
+
+  scaleup_url:
+    value: {get_attr: [vm_scaleup, signal_url]}
+    description: >
+      Here is hook url of scaleup.
+
+  scaleup_url_by_cfn:
+    value: {get_attr: [vm_scaleup, alarm_url]}
+    description: >
+      Here is hook url of scaleup by using cloud cfn.
+
+  scaledown_url:
+    value: {get_attr: [vm_scaledown, signal_url]}
+    description: >
+      Here is hook url of scaledown.
+
+  scaledown_url_by_cfn:
+    value: {get_attr: [vm_scaledown, alarm_url]}
+    description: >
+      Here is hook url of scaledown by using cloud cfn.
+
+

--- a/util.sh
+++ b/util.sh
@@ -123,6 +123,30 @@ function run-heat-script() {
   fi
 }
 
+function update-heat-script() {
+  local stack_status=$(openstack stack show ${STACK_NAME})
+
+  if [[ $stack_status ]]; then
+    echo "[INFO] Update stack ${STACK_NAME}"
+    openstack stack update --timeout 60 \
+      --parameter external_network=${EXTERNAL_NETWORK} \
+      --parameter ssh_key_name=${KUBERNETES_KEYPAIR_NAME} \
+      --parameter server_image=${IMAGE_ID} \
+      --parameter master_flavor=${MASTER_FLAVOR} \
+      --parameter minion_flavor=${MINION_FLAVOR} \
+      --parameter number_of_minions=${NUMBER_OF_MINIONS} \
+      --parameter max_number_of_minions=${MAX_NUMBER_OF_MINIONS} \
+      --parameter dns_nameserver=${DNS_SERVER} \
+      --parameter docker_registry_url=${DOCKER_REGISTRY_URL} \
+      --parameter docker_registry_prefix=${DOCKER_REGISTRY_PREFIX} \
+      --template kubecluster.yaml \
+      ${STACK_NAME}
+  else
+    echo "[INFO] Stack ${STACK_NAME} does not exist"
+    openstack stack show ${STACK_NAME}
+  fi
+}
+
 # Configure kubectl.
 #
 # Assumed vars:


### PR DESCRIPTION
This PR is for discussion.

We have two options to scaleup and scaledown of node.
1. using heat update
   - change env value of NUMBER_OF_MINIONS and MAX_NUMBER_OF_MINIONS.
   - ./kube-update.sh
   
   Pro:
   It is easy.
   
   Con:
   If user update CLC version whose template is changed, user cannnot change size of existing cluster because heat update fails.
2. using OS::Heat::ScalingPolicy
   - add the resource into heat
   - call signal_url or alarm_url which are attributes of OS::Heat::ScalingPolicy.
     
     alarm_url: This needs heat-cfn service.
     heat-cfn service is provided by some OpenStack providers(K5, citycloud, rackspace..)
     
     ```
     heat output-show KubernetesStack scaleup_url_by_cfn
     curl -X POST (above url)  #  It doesn't need authentication.
     ```
     
     signal_url: This needs auth token but doesn't need other services. 
     But  this is supported after liberty in document. but it works in kilo...
     
     ```
     heat output-show KubernetesStack scaleup_url
     curl -s \
     -X POST \
     -H "X-Auth-Token: $OS_TOKEN" \
     -H "Content-Type: application/json" (above url)
     ```
   
   Pro:
   Even if CLC version change, existing cluster work as before.
   
   Con:
   Scaling size is const in HOT. In this PR, it is +1/-1.
   And second signal does not work until scale up finish in my environment.
   So user cannot specify any size.

Proposal: 

If we use heat update, we have all version's template in horizon plugin.

If we use scaling policy,  HOT has some scallingPolicy ;ex)scaleup1_url, scaleup3_url, scaleup5_url...

I like first one  better than second.

Waht do you think?
Do you have any other idea?

@cheld  @batikanu @zreigz @kenan435 
