### PR TITLE
Fix script to make compatible with Horizon plug-in.

### DIFF
--- a/kubecluster.yaml
+++ b/kubecluster.yaml
@@ -77,12 +77,12 @@ parameters:
   docker_registry_url:
     type: string
     description: Docker registry url
-    default:
+    default: ""
 
   docker_registry_prefix:
     type: string
     description: Docker registry prefix for k8s images
-    default:
+    default: ""
 
 resources:
 


### PR DESCRIPTION
Default values need to be defined with "" when declaring them as empty strings.
