### PR TITLE
Fix alignment in scripts

### DIFF
--- a/master.sh
+++ b/master.sh
@@ -95,126 +95,126 @@ command_exists() {
 
 # Detect the OS distro, we support ubuntu, debian, mint, centos, fedora dist.
 detect_lsb() {
-    # TODO: remove this when ARM support is fully merged
-    case "$(uname -m)" in
-        *64)
-            ;;
-         *)
-            echo "Error: We currently only support 64-bit platforms."
-            exit 1
-            ;;
-    esac
+	# TODO: remove this when ARM support is fully merged
+	case "$(uname -m)" in
+	*64)
+		;;
+	*)
+		echo "Error: We currently only support 64-bit platforms."
+		exit 1
+		;;
+	esac
 
-    if command_exists lsb_release; then
-        lsb_dist="$(lsb_release -si)"
-    fi
-    if [ -z ${lsb_dist} ] && [ -r /etc/lsb-release ]; then
-        lsb_dist="$(. /etc/lsb-release && echo "$DISTRIB_ID")"
-    fi
-    if [ -z ${lsb_dist} ] && [ -r /etc/debian_version ]; then
-        lsb_dist='debian'
-    fi
-    if [ -z ${lsb_dist} ] && [ -r /etc/fedora-release ]; then
-        lsb_dist='fedora'
-    fi
-    if [ -z ${lsb_dist} ] && [ -r /etc/os-release ]; then
-        lsb_dist="$(. /etc/os-release && echo "$ID")"
-    fi
+	if command_exists lsb_release; then
+		lsb_dist="$(lsb_release -si)"
+	fi
+	if [ -z ${lsb_dist} ] && [ -r /etc/lsb-release ]; then
+		lsb_dist="$(. /etc/lsb-release && echo "$DISTRIB_ID")"
+	fi
+	if [ -z ${lsb_dist} ] && [ -r /etc/debian_version ]; then
+		lsb_dist='debian'
+	fi
+	if [ -z ${lsb_dist} ] && [ -r /etc/fedora-release ]; then
+		lsb_dist='fedora'
+	fi
+	if [ -z ${lsb_dist} ] && [ -r /etc/os-release ]; then
+		lsb_dist="$(. /etc/os-release && echo "$ID")"
+	fi
 
-    lsb_dist="$(echo ${lsb_dist} | tr '[:upper:]' '[:lower:]')"
+	lsb_dist="$(echo ${lsb_dist} | tr '[:upper:]' '[:lower:]')"
 
-    case "${lsb_dist}" in
-        amzn|centos|debian|ubuntu)
-            ;;
-        *)
-            echo "Error: We currently only support ubuntu|debian|amzn|centos."
-            exit 1
-            ;;
-    esac
+	case "${lsb_dist}" in
+	amzn|centos|debian|ubuntu)
+		;;
+	*)
+		echo "Error: We currently only support ubuntu|debian|amzn|centos."
+		exit 1
+		;;
+	esac
 }
 
 configure_docker(){
-	  # Configure docker settings, then restart it.
-    case "${lsb_dist}" in
-        amzn)
-            DOCKER_CONF="/etc/sysconfig/docker"
-            sed -i.bak 's/^\(MountFlags=\).*/\1shared/' $DOCKER_CONF
-            service docker restart
-            ;;
-        centos)
-            DOCKER_CONF="/usr/lib/systemd/system/docker.service"
-            sed -i.bak 's/^\(MountFlags=\).*/\1shared/' ${DOCKER_CONF}
-            # Add support for docker registry
-            if [[ -n ${DOCKER_REGISTRY_URL} ]]; then
-         sed -i "/^ExecStart=/ s~$~ --insecure-registry=${DOCKER_REGISTRY_URL}~" ${DOCKER_CONF}
-       fi
-            systemctl daemon-reload
-            systemctl restart docker
-            ;;
-        ubuntu|debian)
-            if command_exists systemctl; then
-              DOCKER_CONF=$(systemctl cat docker | head -1 | awk '{print $2}')
-              sed -i.bak 's/^\(MountFlags=\).*/\1shared/' $DOCKER_CONF
-              systemctl daemon-reload
-              systemctl restart docker
-            else
-              DOCKER_CONF="/etc/default/docker"
-              sed -i.bak 's/^\(MountFlags=\).*/\1shared/' $DOCKER_CONF
-              service docker stop
-              while [ `ps aux | grep /usr/bin/docker | grep -v grep | wc -l` -gt 0 ]; do
-                 echo "Waiting for docker to terminate"
-                 sleep 1
-              done
-              service docker start
-            fi
-            ;;
-        *)
-            echo "Unsupported operations system ${lsb_dist}"
-            exit 1
-            ;;
-    esac
+	# Configure docker settings, then restart it.
+	case "${lsb_dist}" in
+	amzn)
+		DOCKER_CONF="/etc/sysconfig/docker"
+		sed -i.bak 's/^\(MountFlags=\).*/\1shared/' $DOCKER_CONF
+		service docker restart
+		;;
+	centos)
+		DOCKER_CONF="/usr/lib/systemd/system/docker.service"
+		sed -i.bak 's/^\(MountFlags=\).*/\1shared/' ${DOCKER_CONF}
+		# Add support for docker registry
+		if [[ -n ${DOCKER_REGISTRY_URL} ]]; then
+			sed -i "/^ExecStart=/ s~$~ --insecure-registry=${DOCKER_REGISTRY_URL}~" ${DOCKER_CONF}
+		fi
+		systemctl daemon-reload
+		systemctl restart docker
+		;;
+	ubuntu|debian)
+		if command_exists systemctl; then
+			DOCKER_CONF=$(systemctl cat docker | head -1 | awk '{print $2}')
+			sed -i.bak 's/^\(MountFlags=\).*/\1shared/' $DOCKER_CONF
+			systemctl daemon-reload
+			systemctl restart docker
+		else
+			DOCKER_CONF="/etc/default/docker"
+			sed -i.bak 's/^\(MountFlags=\).*/\1shared/' $DOCKER_CONF
+			service docker stop
+			while [ `ps aux | grep /usr/bin/docker | grep -v grep | wc -l` -gt 0 ]; do
+				echo "Waiting for docker to terminate"
+				sleep 1
+			done
+			service docker start
+		fi
+		;;
+	*)
+		echo "Unsupported operations system ${lsb_dist}"
+		exit 1
+		;;
+	esac
 }
 
 setup_cluster_connectivity(){
-    # Start etcd
-    docker run \
-        --restart=${RESTART_POLICY} \
-        --net=host \
-        -d \
-        ${ETCD_IMAGE} \
-        /usr/local/bin/etcd \
-            --listen-client-urls=http://127.0.0.1:4001,http://${MASTER_IP}:4001 \
-            --advertise-client-urls=http://${MASTER_IP}:4001 \
-            --data-dir=/var/etcd/data
+	# Start etcd
+	docker run \
+		--restart=${RESTART_POLICY} \
+		--net=host \
+		-d \
+		${ETCD_IMAGE} \
+		/usr/local/bin/etcd \
+			--listen-client-urls=http://127.0.0.1:4001,http://${MASTER_IP}:4001 \
+			--advertise-client-urls=http://${MASTER_IP}:4001 \
+			--data-dir=/var/etcd/data
 
-    sleep 5
-    # Set flannel net config
-    docker run \
-        --net=host ${ETCD_IMAGE} \
-        etcdctl \
-        set /coreos.com/network/config \
-            '{ "Network": "10.1.0.0/16", "Backend": {"Type": "vxlan"}}'
+	sleep 5
+	# Set flannel net config
+	docker run \
+		--net=host ${ETCD_IMAGE} \
+		etcdctl set \
+			/coreos.com/network/config \
+			'{ "Network": "10.1.0.0/16", "Backend": {"Type": "vxlan"}}'
 
-    # Make sure there is no subnet.env from previous run.
-    if [[ -f ${FLANNEL_SUBNET_DIR}/subnet.env ]]; then
+	# Make sure there is no subnet.env from previous run.
+	if [[ -f ${FLANNEL_SUBNET_DIR}/subnet.env ]]; then
 		rm ${FLANNEL_SUBNET_DIR}/subnet.env
-    fi
+	fi
 
-    # iface may change to a private network interface, eth0 is for default
-    docker run \
-        --restart=${RESTART_POLICY} \
-        -d \
-        --net=host \
-        --privileged \
-        -v /dev/net:/dev/net \
-        -v ${FLANNEL_SUBNET_DIR}:${FLANNEL_SUBNET_DIR} \
-        ${FLANNEL_IMAGE} \
-        /opt/bin/flanneld \
-            --ip-masq="${FLANNEL_IPMASQ}" \
-            --iface="${FLANNEL_IFACE}"
+	# iface may change to a private network interface, eth0 is for default
+	docker run \
+		--restart=${RESTART_POLICY} \
+		-d \
+		--net=host \
+		--privileged \
+		-v /dev/net:/dev/net \
+		-v ${FLANNEL_SUBNET_DIR}:${FLANNEL_SUBNET_DIR} \
+		${FLANNEL_IMAGE} \
+		/opt/bin/flanneld \
+			--ip-masq="${FLANNEL_IPMASQ}" \
+			--iface="${FLANNEL_IFACE}"
 
-  # Wait for the flannel subnet.env file to be created instead of a timeout. This is faster and more reliable
-  local SECONDS=0
+	# Wait for the flannel subnet.env file to be created instead of a timeout. This is faster and more reliable
+	local SECONDS=0
 	while [[ ! -f ${FLANNEL_SUBNET_DIR}/subnet.env ]]; do
 		if [[ ${SECONDS} == ${TIMEOUT_FOR_SERVICES} ]]; then
 			echo "flannel failed to start. Exiting..."
@@ -226,55 +226,55 @@ setup_cluster_connectivity(){
 
 # Start k8s components in a hyperkube container.
 start_k8s_as_hyperkube(){
-    mkdir -p /var/lib/kubelet
-    mount --bind /var/lib/kubelet /var/lib/kubelet
-    mount --make-shared /var/lib/kubelet
+	mkdir -p /var/lib/kubelet
+	mount --bind /var/lib/kubelet /var/lib/kubelet
+	mount --make-shared /var/lib/kubelet
 
-    docker run \
-        --name=kubelet \
-        --volume=/:/rootfs:ro \
-        --volume=/sys:/sys:ro \
-        --volume=/var/lib/docker/:/var/lib/docker:rw \
-        --volume=/var/run:/var/run:rw \
-        --volume=/run:/run:rw \
-        --volume=/var/lib/kubelet:/var/lib/kubelet:shared \
-        --net=host \
-        --pid=host \
-        --privileged=true \
-        --restart=${RESTART_POLICY} \
-        -d \
-        ${HYPERKUBE_IMAGE} \
-        /hyperkube kubelet \
-            --hostname-override=${MASTER_IP} \
-            --address="0.0.0.0" \
-            --api-servers=http://localhost:8080 \
-            --config=/etc/kubernetes/manifests-multi \
-            --cluster-dns=10.0.0.10 \
-            --cluster-domain=cluster.local \
-            --allow-privileged=true --v=2 \
-            --pod-infra-container-image=${PAUSE_IMAGE} \
-            --network-plugin=cni \
-            --network-plugin-dir=/etc/cni/net.d
+	docker run \
+		--name=kubelet \
+		--volume=/:/rootfs:ro \
+		--volume=/sys:/sys:ro \
+		--volume=/var/lib/docker/:/var/lib/docker:rw \
+		--volume=/var/run:/var/run:rw \
+		--volume=/run:/run:rw \
+		--volume=/var/lib/kubelet:/var/lib/kubelet:shared \
+		--net=host \
+		--pid=host \
+		--privileged=true \
+		--restart=${RESTART_POLICY} \
+		-d \
+		${HYPERKUBE_IMAGE} \
+		/hyperkube kubelet \
+			--hostname-override=${MASTER_IP} \
+			--address="0.0.0.0" \
+			--api-servers=http://localhost:8080 \
+			--config=/etc/kubernetes/manifests-multi \
+			--cluster-dns=10.0.0.10 \
+			--cluster-domain=cluster.local \
+			--allow-privileged=true --v=2 \
+			--pod-infra-container-image=${PAUSE_IMAGE} \
+			--network-plugin=cni \
+			--network-plugin-dir=/etc/cni/net.d
 }
 
 # Install k8s as a systemd service directly on host.
 start_k8s_as_service(){
-    echo "Installing k8s as a service ..."
-    docker run -d \
-        --volume=/:/hostfs:rw \
-        --net=host \
-        --pid=host \
-        --privileged \
-        taimir93/hyperkube-amd64:v1.3.0-beta.2 \
-        /setup/install.sh master localhost ${MASTER_IP} ${PAUSE_IMAGE}
+	echo "Installing k8s as a service ..."
+	docker run -d \
+		--volume=/:/hostfs:rw \
+		--net=host \
+		--pid=host \
+		--privileged \
+		taimir93/hyperkube-amd64:v1.3.0-beta.2 \
+		/setup/install.sh master localhost ${MASTER_IP} ${PAUSE_IMAGE}
 
-    sleep 3
+	sleep 3
 
-    echo "Running kubelet ..."
-    systemctl daemon-reload
-    systemctl start kubelet
-    systemctl enable kubelet
-    systemctl status kubelet
+	echo "Running kubelet ..."
+	systemctl daemon-reload
+	systemctl start kubelet
+	systemctl enable kubelet
+	systemctl status kubelet
 }
 
 set -e

--- a/worker.sh
+++ b/worker.sh
@@ -95,108 +95,108 @@ init() {
 
 # Check if a command is valid
 command_exists() {
-    command -v "$@" > /dev/null 2>&1
+	command -v "$@" > /dev/null 2>&1
 }
 
 # Detect the OS distro, we support ubuntu, debian, mint, centos, fedora dist
 detect_lsb() {
-    case "$(uname -m)" in
-        *64)
-            ;;
-        *)
-	        echo "Error: We currently only support 64-bit platforms."
-	        exit 1
-	        ;;
-    esac
+	case "$(uname -m)" in
+	*64)
+		;;
+	*)
+		echo "Error: We currently only support 64-bit platforms."
+		exit 1
+		;;
+	esac
 
-    if command_exists lsb_release; then
-        lsb_dist="$(lsb_release -si)"
-    fi
-    if [ -z ${lsb_dist} ] && [ -r /etc/lsb-release ]; then
-        lsb_dist="$(. /etc/lsb-release && echo "$DISTRIB_ID")"
-    fi
-    if [ -z ${lsb_dist} ] && [ -r /etc/debian_version ]; then
-        lsb_dist='debian'
-    fi
-    if [ -z ${lsb_dist} ] && [ -r /etc/fedora-release ]; then
-        lsb_dist='fedora'
-    fi
-    if [ -z ${lsb_dist} ] && [ -r /etc/os-release ]; then
-        lsb_dist="$(. /etc/os-release && echo "$ID")"
-    fi
+	if command_exists lsb_release; then
+		lsb_dist="$(lsb_release -si)"
+	fi
+	if [ -z ${lsb_dist} ] && [ -r /etc/lsb-release ]; then
+		lsb_dist="$(. /etc/lsb-release && echo "$DISTRIB_ID")"
+	fi
+	if [ -z ${lsb_dist} ] && [ -r /etc/debian_version ]; then
+		lsb_dist='debian'
+	fi
+	if [ -z ${lsb_dist} ] && [ -r /etc/fedora-release ]; then
+		lsb_dist='fedora'
+	fi
+	if [ -z ${lsb_dist} ] && [ -r /etc/os-release ]; then
+		lsb_dist="$(. /etc/os-release && echo "$ID")"
+	fi
 
-    lsb_dist="$(echo ${lsb_dist} | tr '[:upper:]' '[:lower:]')"
+	lsb_dist="$(echo ${lsb_dist} | tr '[:upper:]' '[:lower:]')"
 
-    case "${lsb_dist}" in
-        amzn|centos|debian|ubuntu)
-            ;;
-        *)
-            echo "Error: We currently only support ubuntu|debian|amzn|centos."
-            exit 1
-            ;;
-    esac
+	case "${lsb_dist}" in
+	amzn|centos|debian|ubuntu)
+		;;
+	*)
+		echo "Error: We currently only support ubuntu|debian|amzn|centos."
+		exit 1
+		;;
+	esac
 }
 
 configure_docker(){
-		# Configure docker settings, then restart it
-    case "${lsb_dist}" in
-        amzn)
-            DOCKER_CONF="/etc/sysconfig/docker"
-            sed -i.bak 's/^\(MountFlags=\).*/\1shared/' $DOCKER_CONF
-            service docker restart
-            ;;
-        centos)
-            DOCKER_CONF="/usr/lib/systemd/system/docker.service"
-            sed -i.bak 's/^\(MountFlags=\).*/\1shared/' ${DOCKER_CONF}
-            # Add support for docker registry
-            if [[ -n ${DOCKER_REGISTRY_URL} ]]; then
-			  sed -i "/^ExecStart=/ s~$~ --insecure-registry=${DOCKER_REGISTRY_URL}~" ${DOCKER_CONF}
-			fi
-            systemctl daemon-reload
-            systemctl restart docker
-            ;;
-        ubuntu|debian)
-            if command_exists systemctl; then
-              DOCKER_CONF=$(systemctl cat docker | head -1 | awk '{print $2}')
-              sed -i.bak 's/^\(MountFlags=\).*/\1shared/' $DOCKER_CONF
-              systemctl daemon-reload
-              systemctl restart docker
-            else
-              DOCKER_CONF="/etc/default/docker"
-              sed -i.bak 's/^\(MountFlags=\).*/\1shared/' $DOCKER_CONF
-              service docker stop
-              while [ `ps aux | grep /usr/bin/docker | grep -v grep | wc -l` -gt 0 ]; do
-                 echo "Waiting for docker to terminate"
-                 sleep 1
-              done
-              service docker start
-            fi
-            ;;
-        *)
-            echo "Unsupported operations system ${lsb_dist}"
-            exit 1
-            ;;
-    esac
+	# Configure docker settings, then restart it
+	case "${lsb_dist}" in
+	amzn)
+		DOCKER_CONF="/etc/sysconfig/docker"
+		sed -i.bak 's/^\(MountFlags=\).*/\1shared/' $DOCKER_CONF
+		service docker restart
+		;;
+	centos)
+		DOCKER_CONF="/usr/lib/systemd/system/docker.service"
+		sed -i.bak 's/^\(MountFlags=\).*/\1shared/' ${DOCKER_CONF}
+		# Add support for docker registry
+		if [[ -n ${DOCKER_REGISTRY_URL} ]]; then
+			sed -i "/^ExecStart=/ s~$~ --insecure-registry=${DOCKER_REGISTRY_URL}~" ${DOCKER_CONF}
+		fi
+		systemctl daemon-reload
+		systemctl restart docker
+		;;
+	ubuntu|debian)
+		if command_exists systemctl; then
+			DOCKER_CONF=$(systemctl cat docker | head -1 | awk '{print $2}')
+			sed -i.bak 's/^\(MountFlags=\).*/\1shared/' $DOCKER_CONF
+			systemctl daemon-reload
+			systemctl restart docker
+		else
+			DOCKER_CONF="/etc/default/docker"
+			sed -i.bak 's/^\(MountFlags=\).*/\1shared/' $DOCKER_CONF
+			service docker stop
+			while [ `ps aux | grep /usr/bin/docker | grep -v grep | wc -l` -gt 0 ]; do
+				echo "Waiting for docker to terminate"
+				sleep 1
+			done
+			service docker start
+		fi
+		;;
+	*)
+		echo "Unsupported operations system ${lsb_dist}"
+		exit 1
+		;;
+	esac
 }
 
 setup_cluster_connectivity(){
-    # Make sure there is no subnet.env from previous run.
-    if [[ -f ${FLANNEL_SUBNET_DIR}/subnet.env ]]; then
+	# Make sure there is no subnet.env from previous run.
+	if [[ -f ${FLANNEL_SUBNET_DIR}/subnet.env ]]; then
 		rm ${FLANNEL_SUBNET_DIR}/subnet.env
-    fi
+	fi
 	# Start flannel
-    docker run \
-        -d \
-        --restart=${RESTART_POLICY} \
-        --net=host \
-        --privileged \
-        -v /dev/net:/dev/net \
-        -v ${FLANNEL_SUBNET_DIR}:${FLANNEL_SUBNET_DIR} \
-        ${FLANNEL_IMAGE} \
-        /opt/bin/flanneld \
-            --ip-masq="${FLANNEL_IPMASQ}" \
-            --etcd-endpoints=http://${MASTER_IP}:4001 \
-            --iface="${FLANNEL_IFACE}"
+	docker run \
+		-d \
+		--restart=${RESTART_POLICY} \
+		--net=host \
+		--privileged \
+		-v /dev/net:/dev/net \
+		-v ${FLANNEL_SUBNET_DIR}:${FLANNEL_SUBNET_DIR} \
+		${FLANNEL_IMAGE} \
+		/opt/bin/flanneld \
+			--ip-masq="${FLANNEL_IPMASQ}" \
+			--etcd-endpoints=http://${MASTER_IP}:4001 \
+			--iface="${FLANNEL_IFACE}"
 
 	# Wait for the flannel subnet.env file to be created instead of a timeout. This is faster and more reliable
 	local SECONDS=0
@@ -211,34 +211,34 @@ setup_cluster_connectivity(){
 
 # Start k8s components in a hyperkube container.
 start_k8s_as_hyperkube() {
-    mkdir -p /var/lib/kubelet
-    mount --bind /var/lib/kubelet /var/lib/kubelet
-    mount --make-shared /var/lib/kubelet
+	mkdir -p /var/lib/kubelet
+	mount --bind /var/lib/kubelet /var/lib/kubelet
+	mount --make-shared /var/lib/kubelet
 
-    docker run \
-        --name=kubelet \
-        --volume=/:/rootfs:ro \
-        --volume=/sys:/sys:ro \
-        --volume=/var/lib/docker/:/var/lib/docker:rw \
-        --volume=/var/run:/var/run:rw \
-        --volume=/run:/run:rw \
-        --volume=/var/lib/kubelet:/var/lib/kubelet:shared \
-        --net=host \
-        --pid=host \
-        --privileged=true \
-        --restart=${RESTART_POLICY} \
-        -d \
-        ${HYPERKUBE_IMAGE} \
-        /hyperkube kubelet \
-            --hostname-override=${NODE_IP} \
-            --address="0.0.0.0" \
-            --api-servers=http://${MASTER_IP}:8080 \
-            --cluster-dns=10.0.0.10 \
-            --cluster-domain=cluster.local \
-            --allow-privileged=true --v=2  \
-            --pod-infra-container-image=${PAUSE_IMAGE} \
-            --network-plugin=cni \
-            --network-plugin-dir=/etc/cni/net.d
+	docker run \
+		--name=kubelet \
+		--volume=/:/rootfs:ro \
+		--volume=/sys:/sys:ro \
+		--volume=/var/lib/docker/:/var/lib/docker:rw \
+		--volume=/var/run:/var/run:rw \
+		--volume=/run:/run:rw \
+		--volume=/var/lib/kubelet:/var/lib/kubelet:shared \
+		--net=host \
+		--pid=host \
+		--privileged=true \
+		--restart=${RESTART_POLICY} \
+		-d \
+		${HYPERKUBE_IMAGE} \
+		/hyperkube kubelet \
+			--hostname-override=${NODE_IP} \
+			--address="0.0.0.0" \
+			--api-servers=http://${MASTER_IP}:8080 \
+			--cluster-dns=10.0.0.10 \
+			--cluster-domain=cluster.local \
+			--allow-privileged=true --v=2  \
+			--pod-infra-container-image=${PAUSE_IMAGE} \
+			--network-plugin=cni \
+			--network-plugin-dir=/etc/cni/net.d
 }
 
 # Install k8s as a systemd service directly on host.


### PR DESCRIPTION
During my last commit I noticed that the indentation of the code is not consistent in the `master.sh` and `worker.sh` scripts. For example, the init() function is `tab` indented, whereas other parts are `space` indented. Also, there were parts where tabs and spaces are mixed. Let's fix this.

I went for `tab` indents everywhere, because I find `tabs` easier to maintain. I can make it all spaces, it is not that important.

@zreigz @batikanu @cheld Let's pick one of `tab`, `2-space` or `4-space` and stick with it.

P.S: I'll do `worker.sh` next, when we settle on what indentation to use.
