### PR TITLE
Cluster DNS ip address falls within the new service-cluster-ip-range

### DIFF
--- a/master.sh
+++ b/master.sh
@@ -250,7 +250,7 @@ start_k8s_as_hyperkube(){
 			--address="0.0.0.0" \
 			--api-servers=http://localhost:8080 \
 			--config=/etc/kubernetes/manifests-multi \
-			--cluster-dns=10.0.0.10 \
+			--cluster-dns=10.10.0.10 \
 			--cluster-domain=cluster.local \
 			--allow-privileged=true --v=2 \
 			--pod-infra-container-image=${PAUSE_IMAGE} \

--- a/worker.sh
+++ b/worker.sh
@@ -234,7 +234,7 @@ start_k8s_as_hyperkube() {
 			--hostname-override=${NODE_IP} \
 			--address="0.0.0.0" \
 			--api-servers=http://${MASTER_IP}:8080 \
-			--cluster-dns=10.0.0.10 \
+			--cluster-dns=10.10.0.10 \
 			--cluster-domain=cluster.local \
 			--allow-privileged=true --v=2  \
 			--pod-infra-container-image=${PAUSE_IMAGE} \


### PR DESCRIPTION
Since we changed the service-cluster-ip-range due to incompatibility with openstack's overlay network IP range we also needed to adjust the cluster-dns ip address to be with that ip range. 
